### PR TITLE
Add type handler to paste value into terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The main part of public interface through which component communicates with oute
 3. `focus: () => void` - focuses terminal input
 4. `lock: (payload: boolean) => void` - locks/unlocks terminal input preventing any user attempt to enter a command
 5. `loading: (payload: boolean) => void` - starts/ends loader. **Important!** Loading start locks input automatically, if it is not locked yet. Loading end unlocks input automatically, if it was locked **by loader**
+6. `type: (payload: string) => void` - prints message in terminal's command line. **Important!** Type is async operation, so your next message will be printed as soon as the previous one is finished
 
 You can use these handlers everywhere to fully control behavior of tour terminal.
 

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -23,7 +23,7 @@ foooooooooooooooooooooooooooooooooooooooooo
 
 export default function Web() {
   const eventQueue = useEventQueue();
-  const { lock, loading, clear, print, focus } = eventQueue.handlers;
+  const { lock, loading, clear, print, type, focus } = eventQueue.handlers;
   return (
     <Layout>
       <main className={classes.mainContainer}>
@@ -131,6 +131,9 @@ export default function Web() {
           type="button"
         >
           Print
+        </button>
+        <button className={classes.button} onClick={() => type('Hello')} type="button">
+          Type
         </button>
         <button className={classes.button} onClick={() => focus()} type="button">
           Focus

--- a/packages/crt-terminal/src/hooks/eventQueue/terminalQueue/useSubscribeTerminalQueue.ts
+++ b/packages/crt-terminal/src/hooks/eventQueue/terminalQueue/useSubscribeTerminalQueue.ts
@@ -5,7 +5,7 @@ import { TerminalEvents, TerminalQueueEvents, TerminalQueueReturnType } from './
 
 type ControllerTerminalHandlers = Pick<
   TerminalControllerReturnType['handlers'],
-  'focus' | 'loading' | 'lock'
+  'focus' | 'loading' | 'lock' | 'type'
 >;
 
 interface SubscribeQueueProps {
@@ -16,7 +16,7 @@ interface SubscribeQueueProps {
 type SubscribeQueueReturnType = ReturnType<typeof useSubscribeTerminalQueue>;
 
 function useSubscribeTerminalQueue({
-  controller: { focus, loading, lock },
+  controller: { focus, loading, lock, type },
   queue: {
     state: queueState,
     handlers: { dequeue, nextEvent },
@@ -37,6 +37,10 @@ function useSubscribeTerminalQueue({
         break;
       case TerminalEvents.LOCK:
         lock(event.payload);
+        dequeue(nullifyActiveEvent);
+        break;
+      case TerminalEvents.TYPE:
+        type(event.payload);
         dequeue(nullifyActiveEvent);
         break;
       default:

--- a/packages/crt-terminal/src/hooks/eventQueue/terminalQueue/useTerminalQueue.ts
+++ b/packages/crt-terminal/src/hooks/eventQueue/terminalQueue/useTerminalQueue.ts
@@ -4,6 +4,7 @@ enum TerminalEvents {
   FOCUS = 'FOCUS',
   LOCK = 'LOCK',
   LOADING = 'LOADING',
+  TYPE = 'TYPE',
 }
 
 interface FocusEvent {
@@ -20,7 +21,12 @@ interface LoadingEvent {
   payload: boolean;
 }
 
-type TerminalQueueEvents = FocusEvent | LockEvent | LoadingEvent;
+interface TypeEvent {
+  type: TerminalEvents.TYPE;
+  payload: string;
+}
+
+type TerminalQueueEvents = FocusEvent | LockEvent | LoadingEvent | TypeEvent;
 
 type TerminalQueue = TerminalQueueEvents[];
 
@@ -64,17 +70,32 @@ function useTerminalQueue() {
     });
   };
 
+  const type = (payload: string) => {
+    enqueue({
+      type: TerminalEvents.TYPE,
+      payload,
+    });
+  };
+
   return {
     state: queueState,
     handlers: {
       focus,
       lock,
       loading,
+      type,
       dequeue,
       nextEvent,
     },
   };
 }
 
-export type { FocusEvent, LockEvent, LoadingEvent, TerminalQueueEvents, TerminalQueueReturnType };
+export type {
+  FocusEvent,
+  LockEvent,
+  LoadingEvent,
+  TypeEvent,
+  TerminalQueueEvents,
+  TerminalQueueReturnType,
+};
 export { useTerminalQueue, TerminalEvents };

--- a/packages/crt-terminal/src/hooks/eventQueue/useEventQueue.ts
+++ b/packages/crt-terminal/src/hooks/eventQueue/useEventQueue.ts
@@ -6,9 +6,10 @@ import {
   FocusEvent,
   LockEvent,
   LoadingEvent,
+  TypeEvent,
 } from './terminalQueue/useTerminalQueue';
 
-type InterfaceEvent = FocusEvent | ClearEvent | PrintEvent | LockEvent | LoadingEvent;
+type InterfaceEvent = FocusEvent | ClearEvent | PrintEvent | LockEvent | LoadingEvent | TypeEvent;
 
 type EventQueue = InterfaceEvent[];
 
@@ -64,6 +65,13 @@ function useEventQueue() {
     });
   };
 
+  const type = (payload: string) => {
+    enqueue({
+      type: TerminalEvents.TYPE,
+      payload,
+    });
+  };
+
   return {
     state: queueState,
     api: { enqueue, dequeue, nextEvent },
@@ -73,6 +81,7 @@ function useEventQueue() {
       focus,
       lock,
       loading,
+      type,
     },
   };
 }

--- a/packages/crt-terminal/src/hooks/eventQueue/useSubscribeEventQueue.ts
+++ b/packages/crt-terminal/src/hooks/eventQueue/useSubscribeEventQueue.ts
@@ -35,7 +35,12 @@ function useSubscribeEventQueue({
 
   const terminalQueue = useTerminalQueue();
   const {
-    handlers: { focus: terminalFocus, loading: terminalLoading, lock: terminalLock },
+    handlers: {
+      focus: terminalFocus,
+      loading: terminalLoading,
+      lock: terminalLock,
+      type: terminalType,
+    },
   } = terminalQueue;
   useSubscribeTerminalQueue({ queue: terminalQueue, controller });
 
@@ -51,6 +56,10 @@ function useSubscribeEventQueue({
         break;
       case TerminalEvents.LOCK:
         terminalLock(event.payload);
+        dequeue(nullifyActiveEvent);
+        break;
+      case TerminalEvents.TYPE:
+        terminalType(event.payload);
         dequeue(nullifyActiveEvent);
         break;
       case PrinterEvents.CLEAR:

--- a/packages/crt-terminal/src/hooks/useTerminalController.ts
+++ b/packages/crt-terminal/src/hooks/useTerminalController.ts
@@ -74,6 +74,7 @@ function useTerminalController({
     handlers: {
       preventDefault,
       addCharacter,
+      setInput,
       removeCharacter,
       moveCommandCursor,
       submitCommand,
@@ -142,6 +143,10 @@ function useTerminalController({
     if (!inputLocked) addCharacter(newInput);
   };
 
+  const type = (characters: string) => {
+    if (!inputLocked) setInput(characters);
+  };
+
   const handleKeyboardEvent = (key: string) => {
     if (isMoveActions(key)) moveCommandCursor(key);
     if (isRemoveActions(key)) removeCharacter(key);
@@ -190,6 +195,7 @@ function useTerminalController({
       handleInputChange,
       handleKeyboardDown,
       loading,
+      type,
     },
   };
 }


### PR DESCRIPTION
# Feature
Add type handler to allow programmatically paste the value into the terminal.
Can be used

- if you want to provide value via query parameters
- if you want to insert a command by clicking on a button
etc.